### PR TITLE
Disables obsolete cipher suites (SSL and TLS < 1.2)

### DIFF
--- a/mHttp.Sample/Program.cs
+++ b/mHttp.Sample/Program.cs
@@ -107,7 +107,7 @@ namespace m.Sample
 
         public static void Main(string[] args)
         {
-            LoggingProvider.Use(LoggingProvider.NullLoggingProvider);
+            LoggingProvider.Use(LoggingProvider.ConsoleLoggingProvider);
 
             var config = ConfigManager.Load<ServerConfig>();
 
@@ -115,7 +115,6 @@ namespace m.Sample
 
             var server = new HttpBackend(IPAddress.Any, config.ListenPort);
             var routeTable = new RouteTable(
-                //Route.Post("/API/*").With((req) => new HttpResponse(HttpStatusCode.Accepted)),
                 Route.ServeDirectory("/web/*", "./web/"),
                 Route.Get("/").With(wsService.Redirect),
                 Route.GetWebSocketUpgrade("/ws").With(wsService.HandleUpgradeRequest),

--- a/mHttp/Http/Handlers/StaticFileHandler.cs
+++ b/mHttp/Http/Handlers/StaticFileHandler.cs
@@ -82,13 +82,14 @@ namespace m.Http.Handlers
                 }
                 else
                 {
-                    return req.IsAcceptGZip() ? cachedFile.GZippedResponse : cachedFile.Response;
+                    return req.IsAcceptGZip() && cachedFile.GZippedResponse != null ? cachedFile.GZippedResponse : cachedFile.Response;
                 }
             }
             else
             {
                 var fileResponse = new FileResponse(fileInfo);
-                cachedFile = new CachedFile(fileResponse, fileResponse.GZip(gzipFunc));
+
+                cachedFile = new CachedFile(fileResponse, gzipFunc != null ? fileResponse.GZip(gzipFunc) : null);
                 cache[fullName] = cachedFile;
 
                 return req.IsAcceptGZip() ? cachedFile.GZippedResponse : cachedFile.Response;

--- a/mHttp/Http/HttpsBackend.cs
+++ b/mHttp/Http/HttpsBackend.cs
@@ -39,7 +39,7 @@ namespace m.Http
                                                                 TimeSpan _sessionWriteTimeout)
         {
             var sslStream = new SslStream(client.GetStream());
-            await sslStream.AuthenticateAsServerAsync(serverCertificate, false, System.Security.Authentication.SslProtocols.Default, false);
+            await sslStream.AuthenticateAsServerAsync(serverCertificate, false, System.Security.Authentication.SslProtocols.Tls12, false);
 
             return new HttpSession(sessionId, client, sslStream, true, _maxKeepAlives, _sessionReadBufferSize, _sessionReadTimeout, _sessionWriteTimeout);
         }


### PR DESCRIPTION
All cipher suites other than TLS 1.2 are obsolete and a security hazard. As such only 1.2 should be supported by default (the default oddly enough allows only the older suites and not TLS 1.2).

I also don't know why github is insisting on pulling these other commits too. It's just 61f36ca that applies.